### PR TITLE
fix: Bug fix isJsonReq function to handle map headers object that is used in Next.JS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "editor.formatOnSave": false,
     "editor.tabSize": 4,

--- a/index.js
+++ b/index.js
@@ -9,6 +9,15 @@ const jsonContentTypes = [
     'application/hal+json'
 ];
 
+const getReqHeader = (req, name) => {
+    if (req && req.headers) {
+        if (req.headers.get) {
+            return req.headers.get(name);
+        }
+        return req.headers[name];
+    }
+};
+
 /**
  * @function
  * @description Function that check if current request is a json request or not.
@@ -18,7 +27,7 @@ const jsonContentTypes = [
  * @returns {boolean}
  */
 export const isJsonReq = (req) => {
-    const contentType = req && req.headers && req.headers['content-type'];
+    const contentType = getReqHeader(req,'content-type');
 
     const normalizedContentType = contentType && contentType.toLowerCase();
 

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -44,6 +44,15 @@ describe('is-json-request util', () => {
                     }
                 })
             ).to.be.ok();
+
+            const headersMap = new Map();
+            headersMap.set('content-type', 'application/json');
+
+            expect(
+                isJsonReq({
+                    headers: headersMap
+                })
+            ).to.be.ok();
         });
 
         it('should return false', () => {


### PR DESCRIPTION
Bug fix isJsonReq function to handle map headers object that is used in Next.JS
To access request header in Next.JS you need to access the request header map object by using `req.headers.get(headerName)`.